### PR TITLE
Use https by default

### DIFF
--- a/Network/Gravatar.hs
+++ b/Network/Gravatar.hs
@@ -102,7 +102,7 @@ defaultConfig = GravatarOptions
     , gDefault      = Nothing
     , gForceDefault = ForceDefault False
     , gRating       = Nothing
-    , gScheme       = Http
+    , gScheme       = Https
     }
 
 -- | Return the avatar for the given email using the provided options


### PR DESCRIPTION
* Using http causes mixed content warnings on https sites
* Using https works fine for http sites
* Modern privacy and security standards expect https